### PR TITLE
Fixed a typo in the description for the 'start' command

### DIFF
--- a/command/start.go
+++ b/command/start.go
@@ -24,7 +24,7 @@ func (c *Start) Name() string {
 }
 
 func (c *Start) Description() string {
-	return fmt.Sprintf("Starts the daemon that is reposible for tracking time for the current repository, if the daemon is already running this operations is a no-op.")
+	return fmt.Sprintf("Starts the daemon that is reposible for tracking time for the current repository. If the daemon is already running, this operation is a no-op.")
 }
 
 func (c *Start) Usage() string {


### PR DESCRIPTION
I think the proposed change sounds a bit more correct. 
